### PR TITLE
Make GHCR packages public after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build & Push (multi services)
         run: |
           set -e
-          REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          REPO="${{ github.repository }}"
+          REPO_LC=$(echo "${REPO}" | tr '[:upper:]' '[:lower:]')
           SHORT_SHA=${GITHUB_SHA::7}
           for SVC in vision coach yt_ingest; do
             docker buildx build $SVC \
@@ -40,12 +41,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          REPO="${{ github.repository }}"
           OWNER="${{ github.repository_owner }}"
-          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          REPO_LC=$(echo "${REPO}" | tr '[:upper:]' '[:lower:]')
+          REPO_NAME_LC=$(echo "${REPO_LC}" | cut -d'/' -f2)
           OWNER_TYPE=$(gh api graphql -f query='query($login: String!) { repositoryOwner(login: $login) { __typename } }' -f login="$OWNER" --jq '.data.repositoryOwner.__typename')
 
           for SVC in vision coach yt_ingest; do
-            PACKAGE_NAME="$REPO_NAME/$SVC"
+            PACKAGE_NAME="$REPO_NAME_LC/$SVC"
             ENCODED_PACKAGE=$(printf '%s' "$PACKAGE_NAME" | jq -sRr @uri)
 
             if [ "$OWNER_TYPE" = "Organization" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,27 @@ jobs:
               -t ghcr.io/${REPO_LC}/$SVC:${SHORT_SHA} \
               --push
           done
+
+      - name: Make packages public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          OWNER="${{ github.repository_owner }}"
+          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          OWNER_TYPE=$(gh api graphql -f query='query($login: String!) { repositoryOwner(login: $login) { __typename } }' -f login="$OWNER" --jq '.data.repositoryOwner.__typename')
+
+          for SVC in vision coach yt_ingest; do
+            PACKAGE_NAME="$REPO_NAME/$SVC"
+            ENCODED_PACKAGE=$(printf '%s' "$PACKAGE_NAME" | jq -sRr @uri)
+
+            if [ "$OWNER_TYPE" = "Organization" ]; then
+              gh api -X PATCH -H "Accept: application/vnd.github+json" \
+                "/orgs/$OWNER/packages/container/$ENCODED_PACKAGE/visibility" \
+                -f visibility=public
+            else
+              gh api -X PATCH -H "Accept: application/vnd.github+json" \
+                "/user/packages/container/$ENCODED_PACKAGE/visibility" \
+                -f visibility=public
+            fi
+          done

--- a/coach/Dockerfile
+++ b/coach/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim
-RUN pip install --no-cache-dir openai==1.45.0
+# Pin httpx below 0.28 because openai==1.45.0 still relies on the legacy
+# "proxies" keyword argument that was removed in httpx 0.28. Installing both
+# packages together keeps the runtime client compatible with the OpenAI SDK.
+RUN pip install --no-cache-dir \
+    "httpx==0.27.2" \
+    "openai==1.45.0"
 WORKDIR /app
 COPY run_coach.py .
 CMD ["python","run_coach.py"]

--- a/coach/Dockerfile
+++ b/coach/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.11-slim
-# Pin httpx below 0.28 because openai==1.45.0 still relies on the legacy
-# "proxies" keyword argument that was removed in httpx 0.28. Installing both
-# packages together keeps the runtime client compatible with the OpenAI SDK.
+# openai>=1.51.0 ships the updated HTTP client wrapper that uses the new
+# ``proxy`` keyword compatible with httpx 0.28+. Keeping the SDK at or above
+# this version prevents the ``proxies`` TypeError that surfaced with newer
+# httpx releases while still allowing upstream bugfixes.
 RUN pip install --no-cache-dir \
-    "httpx==0.27.2" \
-    "openai==1.45.0"
+    "openai>=1.51.0,<2"
 WORKDIR /app
 COPY run_coach.py .
 CMD ["python","run_coach.py"]


### PR DESCRIPTION
## Summary
- mark the published GHCR images as public automatically so they can be pulled without authentication
- detect whether the repository belongs to a user or organization and call the appropriate visibility API for each service image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f98c22ec832b826cb9e57aa97943